### PR TITLE
Implement multi-salon support

### DIFF
--- a/alembic/versions/001_add_salon_tables.py
+++ b/alembic/versions/001_add_salon_tables.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'salon',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String(length=100), nullable=False, unique=True),
+    )
+    op.add_column('banner', sa.Column('salon_id', sa.Integer, sa.ForeignKey('salon.id'), nullable=False, server_default='1'))
+    op.add_column('category', sa.Column('salon_id', sa.Integer, sa.ForeignKey('salon.id'), nullable=False, server_default='1'))
+    op.add_column('product', sa.Column('salon_id', sa.Integer, sa.ForeignKey('salon.id'), nullable=False, server_default='1'))
+    op.add_column('user', sa.Column('salon_id', sa.Integer, sa.ForeignKey('salon.id'), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'salon_id')
+    op.drop_column('product', 'salon_id')
+    op.drop_column('category', 'salon_id')
+    op.drop_column('banner', 'salon_id')
+    op.drop_table('salon')

--- a/database/engine.py
+++ b/database/engine.py
@@ -2,7 +2,11 @@ import os
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from database.models import Base
-from database.orm_query import orm_add_banner_description, orm_create_categories
+from database.orm_query import (
+    orm_add_banner_description,
+    orm_create_categories,
+    orm_create_salon,
+)
 
 from common.texts_for_db import categories, description_for_info_pages
 
@@ -22,10 +26,10 @@ async def create_db():
         await conn.run_sync(Base.metadata.create_all)
 
     async with session_maker() as session:
-        await orm_create_categories(session, categories)
-        await orm_add_banner_description(session, description_for_info_pages)
+        salon = await orm_create_salon(session, "Default")
+        await orm_create_categories(session, categories, salon.id)
+        await orm_add_banner_description(session, description_for_info_pages, salon.id)
 
 
 async def drop_db():
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+    async with engine.begin() as conn:        await conn.run_sync(Base.metadata.drop_all)

--- a/database/models.py
+++ b/database/models.py
@@ -1,10 +1,25 @@
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, BigInteger, func
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+    BigInteger,
+    func,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
     created: Mapped[DateTime] = mapped_column(DateTime, default=func.now())
     updated: Mapped[DateTime] = mapped_column(DateTime, default=func.now(), onupdate=func.now())
+
+
+class Salon(Base):
+    __tablename__ = "salon"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True)
 
 
 class Banner(Base):
@@ -14,6 +29,9 @@ class Banner(Base):
     name: Mapped[str] = mapped_column(String(15), unique=True)
     image: Mapped[str] = mapped_column(String(150), nullable=True)
     description: Mapped[str] = mapped_column(Text, nullable=True)
+    salon_id: Mapped[int] = mapped_column(ForeignKey('salon.id'), nullable=False)
+
+    salon: Mapped['Salon'] = relationship(backref='banners')
 
 
 class Category(Base):
@@ -21,6 +39,9 @@ class Category(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(150), nullable=False)
+    salon_id: Mapped[int] = mapped_column(ForeignKey('salon.id'), nullable=False)
+
+    salon: Mapped['Salon'] = relationship(backref='categories')
 
 
 class Product(Base):
@@ -32,8 +53,10 @@ class Product(Base):
     price: Mapped[float] = mapped_column(Numeric(5,2), nullable=False)
     image: Mapped[str] = mapped_column(String(150))
     category_id: Mapped[int] = mapped_column(ForeignKey('category.id', ondelete='CASCADE'), nullable=False)
+    salon_id: Mapped[int] = mapped_column(ForeignKey('salon.id'), nullable=False)
 
     category: Mapped['Category'] = relationship(backref='product')
+    salon: Mapped['Salon'] = relationship(backref='product')
 
 
 class User(Base):
@@ -44,6 +67,9 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(150), nullable=True)
     last_name: Mapped[str]  = mapped_column(String(150), nullable=True)
     phone: Mapped[str]  = mapped_column(String(13), nullable=True)
+    salon_id: Mapped[int | None] = mapped_column(ForeignKey('salon.id'), nullable=True)
+
+    salon: Mapped['Salon'] = relationship(backref='users')
 
 
 class Cart(Base):

--- a/database/orm_query.py
+++ b/database/orm_query.py
@@ -3,7 +3,7 @@ from sqlalchemy import select, update, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from database.models import Banner, Cart, Category, Product, User
+from database.models import Banner, Cart, Category, Product, User, Salon
 
 # Простой пагинатор
 class Paginator:
@@ -47,77 +47,101 @@ class Paginator:
         raise IndexError(f'Previous page does not exist. Use has_previous() to check before.')
 
 
+############################ Салоны ###########################################
+
+async def orm_get_salons(session: AsyncSession):
+    result = await session.execute(select(Salon))
+    return result.scalars().all()
+
+
+async def orm_create_salon(session: AsyncSession, name: str) -> Salon:
+    salon = Salon(name=name)
+    session.add(salon)
+    await session.commit()
+    await session.refresh(salon)
+    return salon
+
+
 ############### Работа с баннерами (информационными страницами) ###############
 
-async def orm_add_banner_description(session: AsyncSession, data: dict):
+async def orm_add_banner_description(session: AsyncSession, data: dict, salon_id: int):
     # Проходим по каждому элементу данных
     for name, description in data.items():
         # Проверяем, существует ли баннер с данным именем
-        query = select(Banner).where(Banner.name == name)
+        query = select(Banner).where(Banner.name == name, Banner.salon_id == salon_id)
         result = await session.execute(query)
         banner = result.scalar()
 
         if banner:
             # Обновляем существующий баннер
             await session.execute(
-                update(Banner).where(Banner.name == name).values(description=description)
+                update(Banner)
+                .where(Banner.name == name, Banner.salon_id == salon_id)
+                .values(description=description)
             )
         else:
             # Добавляем новый баннер, если его нет
-            session.add(Banner(name=name, description=description))
+            session.add(Banner(name=name, description=description, salon_id=salon_id))
 
     await session.commit()
 
 
-async def orm_change_banner_image(session: AsyncSession, name: str, image: str):
-    query = update(Banner).where(Banner.name == name).values(image=image)
+async def orm_change_banner_image(session: AsyncSession, name: str, image: str, salon_id: int):
+    query = (
+        update(Banner)
+        .where(Banner.name == name, Banner.salon_id == salon_id)
+        .values(image=image)
+    )
     await session.execute(query)
     await session.commit()
 
 
-async def orm_get_banner(session: AsyncSession, page: str):
-    query = select(Banner).where(Banner.name == page)
+async def orm_get_banner(session: AsyncSession, page: str, salon_id: int):
+    query = select(Banner).where(Banner.name == page, Banner.salon_id == salon_id)
     result = await session.execute(query)
     return result.scalar()
 
 
-async def orm_get_info_pages(session: AsyncSession):
-    query = select(Banner)
+async def orm_get_info_pages(session: AsyncSession, salon_id: int):
+    query = select(Banner).where(Banner.salon_id == salon_id)
     result = await session.execute(query)
     return result.scalars().all()
 
 
 ############################ Категории ######################################
 
-async def orm_get_categories(session: AsyncSession):
-    query = select(Category)
+async def orm_get_categories(session: AsyncSession, salon_id: int):
+    query = select(Category).where(Category.salon_id == salon_id)
     result = await session.execute(query)
     return result.scalars().all()
 
-async def orm_create_categories(session: AsyncSession, categories: list):
-    query = select(Category)
+async def orm_create_categories(session: AsyncSession, categories: list, salon_id: int):
+    query = select(Category).where(Category.salon_id == salon_id)
     result = await session.execute(query)
     if result.first():
         return
-    session.add_all([Category(name=name) for name in categories])
+    session.add_all([Category(name=name, salon_id=salon_id) for name in categories])
     await session.commit()
 
 ############ Админка: добавить/изменить/удалить товар ########################
 
-async def orm_add_product(session: AsyncSession, data: dict):
+async def orm_add_product(session: AsyncSession, data: dict, salon_id: int):
     obj = Product(
         name=data["name"],
         description=data["description"],
         price=float(data["price"]),
         image=data["image"],
         category_id=int(data["category"]),
+        salon_id=salon_id,
     )
     session.add(obj)
     await session.commit()
 
 
-async def orm_get_products(session: AsyncSession, category_id):
-    query = select(Product).where(Product.category_id == int(category_id))
+async def orm_get_products(session: AsyncSession, category_id, salon_id: int):
+    query = select(Product).where(
+        Product.category_id == int(category_id), Product.salon_id == salon_id
+    )
     result = await session.execute(query)
     return result.scalars().all()
 
@@ -128,10 +152,10 @@ async def orm_get_product(session: AsyncSession, product_id: int):
     return result.scalar()
 
 
-async def orm_update_product(session: AsyncSession, product_id: int, data):
+async def orm_update_product(session: AsyncSession, product_id: int, data, salon_id: int):
     query = (
         update(Product)
-        .where(Product.id == product_id)
+        .where(Product.id == product_id, Product.salon_id == salon_id)
         .values(
             name=data["name"],
             description=data["description"],
@@ -144,8 +168,8 @@ async def orm_update_product(session: AsyncSession, product_id: int, data):
     await session.commit()
 
 
-async def orm_delete_product(session: AsyncSession, product_id: int):
-    query = delete(Product).where(Product.id == product_id)
+async def orm_delete_product(session: AsyncSession, product_id: int, salon_id: int):
+    query = delete(Product).where(Product.id == product_id, Product.salon_id == salon_id)
     await session.execute(query)
     await session.commit()
 
@@ -157,14 +181,26 @@ async def orm_add_user(
     first_name: str | None = None,
     last_name: str | None = None,
     phone: str | None = None,
+    salon_id: int | None = None,
 ):
     query = select(User).where(User.user_id == user_id)
     result = await session.execute(query)
     if result.first() is None:
         session.add(
-            User(user_id=user_id, first_name=first_name, last_name=last_name, phone=phone)
+            User(
+                user_id=user_id,
+                first_name=first_name,
+                last_name=last_name,
+                phone=phone,
+                salon_id=salon_id,
+            )
         )
         await session.commit()
+
+
+async def orm_get_user(session: AsyncSession, user_id: int):
+    result = await session.execute(select(User).where(User.user_id == user_id))
+    return result.scalar()
 
 
 ######################## Работа с корзинами #######################################

--- a/handlers/admin_private.py
+++ b/handlers/admin_private.py
@@ -15,6 +15,7 @@ from database.orm_query import (
     orm_get_product,
     orm_get_products,
     orm_update_product,
+    orm_get_salons,
 )
 
 from filters.chat_types import ChatTypeFilter, IsAdmin
@@ -25,6 +26,7 @@ from kbds.reply import get_keyboard
 
 admin_router = Router()
 admin_router.message.filter(ChatTypeFilter(["private"]), IsAdmin())
+ADMIN_SALON: dict[int, int] = {}
 
 
 ADMIN_KB = get_keyboard(
@@ -42,13 +44,30 @@ async def exit_admin_mode(message: types.Message, state: FSMContext):
     await message.answer("Вы вышли из админ-панели.", reply_markup=ReplyKeyboardRemove())
 
 @admin_router.message(Command("admin"))
-async def admin_features(message: types.Message):
+async def admin_features(message: types.Message, session: AsyncSession):
+    args = message.text.split()
+    if len(args) > 1:
+        ADMIN_SALON[message.from_user.id] = int(args[1])
+    if message.from_user.id not in ADMIN_SALON:
+        salons = await orm_get_salons(session)
+        btns = {s.name: f"set_salon_{s.id}" for s in salons}
+        await message.answer("Выберите салон", reply_markup=get_callback_btns(btns))
+        return
     await message.answer("Что хотите сделать?", reply_markup=ADMIN_KB)
+
+
+@admin_router.callback_query(F.data.startswith('set_salon_'))
+async def set_salon(callback: types.CallbackQuery):
+    salon_id = int(callback.data.split('_')[-1])
+    ADMIN_SALON[callback.from_user.id] = salon_id
+    await callback.message.answer("Салон выбран")
+    await callback.answer()
 
 
 @admin_router.message(F.text == 'Ассортимент')
 async def admin_features(message: types.Message, session: AsyncSession):
-    categories = await orm_get_categories(session)
+    salon_id = ADMIN_SALON.get(message.from_user.id)
+    categories = await orm_get_categories(session, salon_id)
     btns = {category.name : f'category_{category.id}' for category in categories}
     await message.answer("Выберите категорию", reply_markup=get_callback_btns(btns=btns))
 
@@ -56,7 +75,8 @@ async def admin_features(message: types.Message, session: AsyncSession):
 @admin_router.callback_query(F.data.startswith('category_'))
 async def starring_at_product(callback: types.CallbackQuery, session: AsyncSession):
     category_id = callback.data.split('_')[-1]
-    for product in await orm_get_products(session, int(category_id)):
+    salon_id = ADMIN_SALON.get(callback.from_user.id)
+    for product in await orm_get_products(session, int(category_id), salon_id):
         await callback.message.answer_photo(
             product.image,
             caption=f"<strong>{product.name}\
@@ -76,7 +96,8 @@ async def starring_at_product(callback: types.CallbackQuery, session: AsyncSessi
 @admin_router.callback_query(F.data.startswith("delete_"))
 async def delete_product_callback(callback: types.CallbackQuery, session: AsyncSession):
     product_id = callback.data.split("_")[-1]
-    await orm_delete_product(session, int(product_id))
+    salon_id = ADMIN_SALON.get(callback.from_user.id)
+    await orm_delete_product(session, int(product_id), salon_id)
 
     await callback.answer("Товар удален")
     await callback.message.answer("Товар удален!")
@@ -90,7 +111,8 @@ class AddBanner(StatesGroup):
 # Отправляем перечень информационных страниц бота и становимся в состояние отправки photo
 @admin_router.message(StateFilter(None), F.text == 'Добавить/Изменить баннер')
 async def add_image2(message: types.Message, state: FSMContext, session: AsyncSession):
-    pages_names = [page.name for page in await orm_get_info_pages(session)]
+    salon_id = ADMIN_SALON.get(message.from_user.id)
+    pages_names = [page.name for page in await orm_get_info_pages(session, salon_id)]
     await message.answer(f"Отправьте фото баннера.\nВ описании укажите для какой страницы:\
                          \n{', '.join(pages_names)}")
     await state.set_state(AddBanner.image)
@@ -101,12 +123,13 @@ async def add_image2(message: types.Message, state: FSMContext, session: AsyncSe
 async def add_banner(message: types.Message, state: FSMContext, session: AsyncSession):
     image_id = message.photo[-1].file_id
     for_page = message.caption.strip()
-    pages_names = [page.name for page in await orm_get_info_pages(session)]
+    salon_id = ADMIN_SALON.get(message.from_user.id)
+    pages_names = [page.name for page in await orm_get_info_pages(session, salon_id)]
     if for_page not in pages_names:
         await message.answer(f"Введите нормальное название страницы, например:\
                          \n{', '.join(pages_names)}")
         return
-    await orm_change_banner_image(session, for_page, image_id,)
+    await orm_change_banner_image(session, for_page, image_id, salon_id)
     await message.answer("Баннер добавлен/изменен.")
     await state.clear()
 
@@ -244,7 +267,8 @@ async def add_description(message: types.Message, state: FSMContext, session: As
             return
         await state.update_data(description=message.text)
 
-    categories = await orm_get_categories(session)
+    salon_id = ADMIN_SALON.get(message.from_user.id)
+    categories = await orm_get_categories(session, salon_id)
     btns = {category.name : str(category.id) for category in categories}
     await message.answer("Выберите категорию", reply_markup=get_callback_btns(btns=btns))
     await state.set_state(AddProduct.category)
@@ -258,7 +282,8 @@ async def add_description2(message: types.Message, state: FSMContext):
 # Ловим callback выбора категории
 @admin_router.callback_query(AddProduct.category)
 async def category_choice(callback: types.CallbackQuery, state: FSMContext , session: AsyncSession):
-    if int(callback.data) in [category.id for category in await orm_get_categories(session)]:
+    salon_id = ADMIN_SALON.get(callback.from_user.id)
+    if int(callback.data) in [category.id for category in await orm_get_categories(session, salon_id)]:
         await callback.answer()
         await state.update_data(category=callback.data)
         await callback.message.answer('Теперь введите цену товара.')
@@ -309,9 +334,11 @@ async def add_image(message: types.Message, state: FSMContext, session: AsyncSes
     data = await state.get_data()
     try:
         if AddProduct.product_for_change:
-            await orm_update_product(session, AddProduct.product_for_change.id, data)
+            salon_id = ADMIN_SALON.get(message.from_user.id)
+            await orm_update_product(session, AddProduct.product_for_change.id, data, salon_id)
         else:
-            await orm_add_product(session, data)
+            salon_id = ADMIN_SALON.get(message.from_user.id)
+            await orm_add_product(session, data, salon_id)
         await message.answer("Товар добавлен/изменен", reply_markup=ADMIN_KB)
         await state.clear()
 

--- a/handlers/user_private.py
+++ b/handlers/user_private.py
@@ -5,11 +5,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.orm_query import (
     orm_add_to_cart,
     orm_add_user,
+    orm_get_salons,
+    orm_get_user,
 )
 
 from filters.chat_types import ChatTypeFilter
 from handlers.menu_processing import get_menu_content
-from kbds.inline import MenuCallBack, get_callback_btns
+from kbds.inline import MenuCallBack, get_callback_btns, SalonCallBack, get_salon_btns
 
 
 
@@ -19,8 +21,24 @@ user_private_router.message.filter(ChatTypeFilter(["private"]))
 
 @user_private_router.message(CommandStart())
 async def start_cmd(message: types.Message, session: AsyncSession):
-    media, reply_markup = await get_menu_content(session, level=0, menu_name="main")
-
+    args = message.text.split()
+    salon_id = int(args[1]) if len(args) > 1 else None
+    user = await orm_get_user(session, message.from_user.id)
+    if salon_id is None and user:
+        salon_id = user.salon_id
+    if salon_id is None:
+        salons = await orm_get_salons(session)
+        await message.answer("Выберите салон", reply_markup=get_salon_btns(salons))
+        return
+    await orm_add_user(
+        session,
+        user_id=message.from_user.id,
+        first_name=message.from_user.first_name,
+        last_name=message.from_user.last_name,
+        phone=None,
+        salon_id=salon_id,
+    )
+    media, reply_markup = await get_menu_content(session, level=0, menu_name="main", user_id=message.from_user.id)
     await message.answer_photo(media.media, caption=media.caption, reply_markup=reply_markup)
 
 
@@ -32,9 +50,30 @@ async def add_to_cart(callback: types.CallbackQuery, callback_data: MenuCallBack
         first_name=user.first_name,
         last_name=user.last_name,
         phone=None,
+        salon_id=(await orm_get_user(session, user.id)).salon_id if await orm_get_user(session, user.id) else None,
     )
     await orm_add_to_cart(session, user_id=user.id, product_id=callback_data.product_id)
     await callback.answer("Товар добавлен в корзину.")
+
+
+@user_private_router.callback_query(SalonCallBack.filter())
+async def choose_salon(callback: types.CallbackQuery, callback_data: SalonCallBack, session: AsyncSession):
+    await orm_add_user(
+        session,
+        user_id=callback.from_user.id,
+        first_name=callback.from_user.first_name,
+        last_name=callback.from_user.last_name,
+        phone=None,
+        salon_id=callback_data.salon_id,
+    )
+    media, reply_markup = await get_menu_content(
+        session,
+        level=0,
+        menu_name="main",
+        user_id=callback.from_user.id,
+    )
+    await callback.message.edit_text("Салон выбран")
+    await callback.message.answer_photo(media.media, caption=media.caption, reply_markup=reply_markup)
 
 
 @user_private_router.callback_query(MenuCallBack.filter())
@@ -54,5 +93,4 @@ async def user_menu(callback: types.CallbackQuery, callback_data: MenuCallBack, 
         user_id=callback.from_user.id,
     )
 
-    await callback.message.edit_media(media=media, reply_markup=reply_markup)
-    await callback.answer()
+    await callback.message.edit_media(media=media, reply_markup=reply_markup)    await callback.answer()

--- a/kbds/inline.py
+++ b/kbds/inline.py
@@ -11,6 +11,10 @@ class MenuCallBack(CallbackData, prefix="menu"):
     product_id: int | None = None
 
 
+class SalonCallBack(CallbackData, prefix="salon"):
+    salon_id: int
+
+
 def get_user_main_btns(*, level: int, sizes: tuple[int] = (2,)):
     keyboard = InlineKeyboardBuilder()
     btns = {
@@ -32,6 +36,18 @@ def get_user_main_btns(*, level: int, sizes: tuple[int] = (2,)):
                                               callback_data=MenuCallBack(level=level, menu_name=menu_name).pack()))
 
     return keyboard.adjust(*sizes).as_markup()
+
+
+def get_salon_btns(salons):
+    keyboard = InlineKeyboardBuilder()
+    for salon in salons:
+        keyboard.add(
+            InlineKeyboardButton(
+                text=salon.name,
+                callback_data=SalonCallBack(salon_id=salon.id).pack(),
+            )
+        )
+    return keyboard.as_markup()
 
 
 def get_user_catalog_btns(*, level: int, categories: list, sizes: tuple[int] = (2,)):


### PR DESCRIPTION
## Summary
- add `Salon` model and relationships
- migrate DB with salon data
- filter queries by `salon_id`
- update user flow to select salon on /start
- limit admin actions to selected salon

## Testing
- `pytest -q` *(fails: TokenValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_686ece26ca48832da17a6568c23786f8