### PR TITLE
Implement salon-aware access control

### DIFF
--- a/alembic/versions/9327819cd17c_initial_tables.py
+++ b/alembic/versions/9327819cd17c_initial_tables.py
@@ -57,6 +57,8 @@ def upgrade() -> None:
     sa.Column('last_name', sa.String(length=150), nullable=True),
     sa.Column('phone', sa.String(length=13), nullable=True),
     sa.Column('salon_id', sa.Integer(), nullable=True),
+    sa.Column('is_super_admin', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    sa.Column('is_salon_admin', sa.Boolean(), nullable=False, server_default=sa.text('false')),
     sa.Column('created', sa.DateTime(), nullable=False),
     sa.Column('updated', sa.DateTime(), nullable=False),
     sa.ForeignKeyConstraint(['salon_id'], ['salon.id'], ),

--- a/database/models.py
+++ b/database/models.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     String,
     Text,
     BigInteger,
+    Boolean,
     func,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -68,6 +69,8 @@ class User(Base):
     last_name: Mapped[str]  = mapped_column(String(150), nullable=True)
     phone: Mapped[str]  = mapped_column(String(13), nullable=True)
     salon_id: Mapped[int | None] = mapped_column(ForeignKey('salon.id'), nullable=True)
+    is_super_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_salon_admin: Mapped[bool] = mapped_column(Boolean, default=False)
 
     salon: Mapped['Salon'] = relationship(backref='users')
 

--- a/filters/chat_types.py
+++ b/filters/chat_types.py
@@ -1,5 +1,8 @@
 from aiogram.filters import Filter
 from aiogram import Bot, types
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.orm_query import orm_get_user
 
 
 class ChatTypeFilter(Filter):
@@ -14,5 +17,14 @@ class IsAdmin(Filter):
     def __init__(self) -> None:
         pass
 
-    async def __call__(self, message: types.Message, bot: Bot) -> bool:
-        return message.from_user.id in bot.my_admins_list
+    async def __call__(self, message: types.Message, bot: Bot, session: AsyncSession) -> bool:
+        if message.from_user.id in bot.my_admins_list:
+            return True
+        user = await orm_get_user(session, message.from_user.id)
+        return bool(user and (user.is_super_admin or user.is_salon_admin))
+
+
+class IsSuperAdmin(Filter):
+    async def __call__(self, message: types.Message, session: AsyncSession) -> bool:
+        user = await orm_get_user(session, message.from_user.id)
+        return bool(user and user.is_super_admin)

--- a/handlers/admin_private.py
+++ b/handlers/admin_private.py
@@ -180,8 +180,9 @@ async def change_product_callback(
     callback: types.CallbackQuery, state: FSMContext, session: AsyncSession
 ):
     product_id = callback.data.split("_")[-1]
+    salon_id = ADMIN_SALON.get(callback.from_user.id)
 
-    product_for_change = await orm_get_product(session, int(product_id))
+    product_for_change = await orm_get_product(session, int(product_id), salon_id)
 
     AddProduct.product_for_change = product_for_change
 

--- a/handlers/menu_processing.py
+++ b/handlers/menu_processing.py
@@ -93,17 +93,17 @@ async def products(session, level, category, page, salon_id):
 
 async def carts(session, level, menu_name, page, user_id, product_id, salon_id):
     if menu_name == "delete":
-        await orm_delete_from_cart(session, user_id, product_id)
+        await orm_delete_from_cart(session, user_id, product_id, salon_id)
         if page > 1:
             page -= 1
     elif menu_name == "decrement":
-        is_cart = await orm_reduce_product_in_cart(session, user_id, product_id)
+        is_cart = await orm_reduce_product_in_cart(session, user_id, product_id, salon_id)
         if page > 1 and not is_cart:
             page -= 1
     elif menu_name == "increment":
-        await orm_add_to_cart(session, user_id, product_id)
+        await orm_add_to_cart(session, user_id, product_id, salon_id)
 
-    carts = await orm_get_user_carts(session, user_id)
+    carts = await orm_get_user_carts(session, user_id, salon_id)
 
     if not carts:
         banner = await orm_get_banner(session, "cart", salon_id)

--- a/handlers/order_processing.py
+++ b/handlers/order_processing.py
@@ -31,8 +31,8 @@ class OrderStates(StatesGroup):
 
 order_router = Router()
 
-async def create_order_summary(session: AsyncSession, user_id: int):
-    cart_items = await orm_get_user_carts(session, user_id)
+async def create_order_summary(session: AsyncSession, user_id: int, salon_id: int):
+    cart_items = await orm_get_user_carts(session, user_id, salon_id)
     summary = "Ваш заказ:\n"
     total_cost = 0
     for item in cart_items:
@@ -49,7 +49,9 @@ async def handle_start_order(callback_query: CallbackQuery, state: FSMContext, s
     await callback_query.message.delete()
 
     # Получение текстового описания заказа
-    order_summary = await create_order_summary(session, user_id)
+    user = await orm_get_user(session, user_id)
+    salon_id = user.salon_id if user else None
+    order_summary = await create_order_summary(session, user_id, salon_id)
 
     # Установим состояние для подтверждения корзины
     await state.set_state(OrderStates.confirming_cart)
@@ -211,7 +213,9 @@ async def confirm_order(callback_query: CallbackQuery, state: FSMContext, sessio
     payment_method = data.get('payment_method', 'Не указан')  # Получаем способ оплаты из состояния
 
     # Получаем детали заказа
-    order_summary = await create_order_summary(session, user_id)
+    user = await orm_get_user(session, user_id)
+    salon_id = user.salon_id if user else None
+    order_summary = await create_order_summary(session, user_id, salon_id)
 
     # Формируем сообщение для администратора
     admin_message = (

--- a/handlers/user_private.py
+++ b/handlers/user_private.py
@@ -52,7 +52,9 @@ async def add_to_cart(callback: types.CallbackQuery, callback_data: MenuCallBack
         phone=None,
         salon_id=(await orm_get_user(session, user.id)).salon_id if await orm_get_user(session, user.id) else None,
     )
-    await orm_add_to_cart(session, user_id=user.id, product_id=callback_data.product_id)
+    user_db = await orm_get_user(session, user.id)
+    salon_id = user_db.salon_id if user_db else None
+    await orm_add_to_cart(session, user_id=user.id, product_id=callback_data.product_id, salon_id=salon_id)
     await callback.answer("Товар добавлен в корзину.")
 
 


### PR DESCRIPTION
## Summary
- extend `User` model with admin role flags
- tighten queries to check `salon_id`
- ensure cart operations and admin/product handlers use salon checks
- expand admin filter logic for role based auth

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError for aiohttp and aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_686efe7be5a4832db65128f7a90bf736