### PR TITLE
Improve admin product management

### DIFF
--- a/database/orm_query.py
+++ b/database/orm_query.py
@@ -183,6 +183,16 @@ async def orm_update_product(session: AsyncSession, product_id: int, data, salon
     await session.commit()
 
 
+async def orm_change_product_image(session: AsyncSession, product_id: int, image: str, salon_id: int):
+    query = (
+        update(Product)
+        .where(Product.id == product_id, Product.salon_id == salon_id)
+        .values(image=image)
+    )
+    await session.execute(query)
+    await session.commit()
+
+
 async def orm_delete_product(session: AsyncSession, product_id: int, salon_id: int):
     query = delete(Product).where(Product.id == product_id, Product.salon_id == salon_id)
     await session.execute(query)

--- a/handlersadmin/products.py
+++ b/handlersadmin/products.py
@@ -3,18 +3,25 @@ from aiogram.types import (
     CallbackQuery,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    Message,
 )
 from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.orm_query import (
     orm_get_categories,
     orm_get_products,
     orm_delete_product,
+    orm_change_product_image,
 )
 from .menu import show_admin_menu
 
 products_router = Router()
+
+
+class EditPhotoFSM(StatesGroup):
+    waiting_for_photo = State()
 
 # --- Клавиатуры ---
 
@@ -70,13 +77,18 @@ async def show_products(callback: CallbackQuery, state: FSMContext, session: Asy
     category_id = int(callback.data.split("_")[-1])
     message_id = data.get("main_message_id") or callback.message.message_id
 
-    # ПЕРЕД отправкой новых товаров УДАЛИ прошлые сообщения с товарами
+    # ПЕРЕД отправкой новых товаров УДАЛЯЕМ прошлые сообщения с товарами
     old_product_msg_ids = data.get("product_msg_ids", [])
-    for msg_id in old_product_msg_ids:
+    if old_product_msg_ids:
         try:
-            await callback.bot.delete_message(chat_id=callback.message.chat.id, message_id=msg_id)
+            await callback.bot.delete_messages(callback.message.chat.id, old_product_msg_ids)
         except Exception as e:
-            print(f"Ошибка удаления старого сообщения с товаром {msg_id}: {e}")
+            print(f"Bulk delete failed: {e}")
+            for msg_id in old_product_msg_ids:
+                try:
+                    await callback.bot.delete_message(callback.message.chat.id, msg_id)
+                except Exception as e:
+                    print(f"Ошибка удаления старого сообщения с товаром {msg_id}: {e}")
 
     # Потом очищаем список
     await state.update_data(product_msg_ids=[])
@@ -145,7 +157,38 @@ async def delete_product(callback: CallbackQuery, state: FSMContext, session: As
 @products_router.callback_query(F.data.startswith("edit_prod_"))
 async def edit_product(callback: CallbackQuery, state: FSMContext):
     product_id = int(callback.data.split("_")[-1])
-    await callback.answer(f"Редактирование товара №{product_id} — в разработке.")
+    await state.set_state(EditPhotoFSM.waiting_for_photo)
+    await state.update_data(edit_product_id=product_id)
+    await callback.message.answer("Отправьте новое фото товара или отмените командой /cancel")
+    await callback.answer()
+
+
+@products_router.message(EditPhotoFSM.waiting_for_photo, F.photo)
+async def save_new_photo(message: Message, state: FSMContext, session: AsyncSession):
+    data = await state.get_data()
+    salon_id = data.get("salon_id")
+    product_id = data.get("edit_product_id")
+    photo_id = message.photo[-1].file_id
+    await orm_change_product_image(session, product_id, photo_id, salon_id)
+    msg_id = data.get("main_message_id") or message.message_id
+    await state.clear()
+    await state.update_data(main_message_id=msg_id, salon_id=salon_id, product_msg_ids=[])
+    await message.answer("Фото товара обновлено ✅")
+    await show_admin_menu(state, message.chat.id, message.bot, session)
+
+
+@products_router.message(EditPhotoFSM.waiting_for_photo)
+async def cancel_edit(message: Message, state: FSMContext, session: AsyncSession):
+    if message.text and message.text.lower() in {"/cancel", "отмена"}:
+        data = await state.get_data()
+        msg_id = data.get("main_message_id") or message.message_id
+        salon_id = data.get("salon_id")
+        await state.clear()
+        await state.update_data(main_message_id=msg_id, salon_id=salon_id)
+        await message.answer("Отменено")
+        await show_admin_menu(state, message.chat.id, message.bot, session)
+    else:
+        await message.answer("Пришлите фотографию или отправьте /cancel")
 
 # 5. Вернуться в меню
 @products_router.callback_query(F.data == "admin_menu")
@@ -154,11 +197,16 @@ async def back_to_menu(callback: CallbackQuery, state: FSMContext, session: Asyn
     product_msg_ids = data.get("product_msg_ids", [])
     print("Удаляем сообщения:", product_msg_ids)
 
-    for msg_id in product_msg_ids:
+    if product_msg_ids:
         try:
-            await callback.bot.delete_message(chat_id=callback.message.chat.id, message_id=msg_id)
+            await callback.bot.delete_messages(callback.message.chat.id, product_msg_ids)
         except Exception as e:
-            print(f"Ошибка удаления {msg_id}: {e}")
+            print(f"Bulk delete failed: {e}")
+            for msg_id in product_msg_ids:
+                try:
+                    await callback.bot.delete_message(callback.message.chat.id, msg_id)
+                except Exception as e:
+                    print(f"Ошибка удаления {msg_id}: {e}")
 
     await state.update_data(product_msg_ids=[])
     await show_admin_menu(state, callback.message.chat.id, callback.bot, session)


### PR DESCRIPTION
## Summary
- add DB helper to change product image
- allow editing product photo via FSM
- delete product messages using bulk API for reliability

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872c3f690f8832db5edc96c2cd80299