### PR TITLE
Implement inline mode support

### DIFF
--- a/handlers/inline_mode.py
+++ b/handlers/inline_mode.py
@@ -1,0 +1,60 @@
+from aiogram import Router
+from aiogram.types import InlineQuery, InlineQueryResultCachedPhoto
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.orm_query import (
+    orm_get_user,
+    orm_get_products,
+    orm_get_categories,
+    orm_get_salon_by_id,
+)
+from utils.currency import get_currency_symbol
+
+inline_router = Router()
+
+
+@inline_router.inline_query()
+async def answer_products_inline(inline_query: InlineQuery, session: AsyncSession):
+    """Return products in inline mode based on query."""
+    user = await orm_get_user(session, inline_query.from_user.id)
+    salon_id = user.salon_id if user else None
+    if not salon_id:
+        await inline_query.answer([], cache_time=1, is_personal=True)
+        return
+
+    query = inline_query.query.strip()
+    category_id = None
+    if query.startswith("cat_"):
+        try:
+            category_id = int(query.split("_", 1)[1])
+        except (ValueError, IndexError):
+            category_id = None
+
+    products = []
+    if category_id is not None:
+        products = await orm_get_products(session, category_id, salon_id)
+    else:
+        categories = await orm_get_categories(session, salon_id)
+        for c in categories:
+            products.extend(await orm_get_products(session, c.id, salon_id))
+
+    salon = await orm_get_salon_by_id(session, salon_id)
+    currency = get_currency_symbol(salon.currency) if salon else "RUB"
+
+    results = []
+    for product in products[:50]:
+        caption = (
+            f"<b>{product.name}</b>\n"
+            f"{product.description}\n"
+            f"Цена: <b>{float(product.price):.2f}{currency}</b>"
+        )
+        results.append(
+            InlineQueryResultCachedPhoto(
+                id=str(product.id),
+                photo_file_id=product.image,
+                caption=caption,
+                parse_mode="HTML",
+            )
+        )
+
+    await inline_query.answer(results, cache_time=1)

--- a/kbds/inline.py
+++ b/kbds/inline.py
@@ -25,15 +25,27 @@ def get_user_main_btns(*, level: int, sizes: tuple[int] = (2,)):
         "Доставка ⛵": "shipping",
     }
     for text, menu_name in btns.items():
-        if menu_name == 'catalog':
-            keyboard.add(InlineKeyboardButton(text=text,
-                                              callback_data=MenuCallBack(level=level + 1, menu_name=menu_name).pack()))
-        elif menu_name == 'cart':
-            keyboard.add(InlineKeyboardButton(text=text,
-                                              callback_data=MenuCallBack(level=3, menu_name=menu_name).pack()))
+        if menu_name == "catalog":
+            keyboard.add(
+                InlineKeyboardButton(
+                    text=text,
+                    switch_inline_query_current_chat="products",
+                )
+            )
+        elif menu_name == "cart":
+            keyboard.add(
+                InlineKeyboardButton(
+                    text=text,
+                    callback_data=MenuCallBack(level=3, menu_name=menu_name).pack(),
+                )
+            )
         else:
-            keyboard.add(InlineKeyboardButton(text=text,
-                                              callback_data=MenuCallBack(level=level, menu_name=menu_name).pack()))
+            keyboard.add(
+                InlineKeyboardButton(
+                    text=text,
+                    callback_data=MenuCallBack(level=level, menu_name=menu_name).pack(),
+                )
+            )
 
     return keyboard.adjust(*sizes).as_markup()
 
@@ -59,9 +71,12 @@ def get_user_catalog_btns(*, level: int, categories: list, sizes: tuple[int] = (
                                       callback_data=MenuCallBack(level=3, menu_name='cart').pack()))
 
     for c in categories:
-        keyboard.add(InlineKeyboardButton(text=c.name,
-                                          callback_data=MenuCallBack(level=level + 1, menu_name=c.name,
-                                                                     category=c.id).pack()))
+        keyboard.add(
+            InlineKeyboardButton(
+                text=c.name,
+                switch_inline_query_current_chat=f"cat_{c.id}",
+            )
+        )
 
     return keyboard.adjust(*sizes).as_markup()
 

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from handlersadmin.settings import settings_router
 from handlers.order_processing import order_router
 from handlers.salon_creation import salon_creation_router
 from handlersadmin.menu import admin_menu_router
+from handlers.inline_mode import inline_router
 
 # ALLOWED_UPDATES = ['message', 'edited_message', 'callback_query']
 
@@ -45,6 +46,7 @@ dp.include_router(settings_router)
 #dp.include_router(admin_router)
 dp.include_router(salon_creation_router)
 dp.include_router(order_router)
+dp.include_router(inline_router)
 
 async def on_startup(bot):
     pass


### PR DESCRIPTION
## Summary
- add inline query handler to output products
- enable switch_inline_query buttons for catalog and categories
- register new router in main app

## Testing
- `python3 -m py_compile $(find . -name '*.py' | grep -v venv)`

------
https://chatgpt.com/codex/tasks/task_e_688392bd74b8832d982cff2cf5d8be39