### PR TITLE
Refactor order summary to leverage user-salon relation

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -92,6 +92,17 @@ class User(Base):
     salon: Mapped['Salon'] = relationship(backref='users')
 
 
+class UserSalon(Base):
+    __tablename__ = 'user_salon'
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey('user.user_id'), nullable=False)
+    salon_id: Mapped[int] = mapped_column(ForeignKey('salon.id'), nullable=False)
+
+    user: Mapped['User'] = relationship(backref='user_salons')
+    salon: Mapped['Salon'] = relationship(backref='user_salons')
+
+
 class Cart(Base):
     __tablename__ = 'cart'
 

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -3,7 +3,7 @@ from aiogram.types import (
 )
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
-from database.orm_query import orm_get_user, orm_get_salon_by_id
+from database.orm_query import orm_get_user, orm_get_user_salon
 from utils.orders import get_order_summary
 
 
@@ -33,14 +33,15 @@ async def notify_salon_about_order(
         print(f"[notify] salon_id не найден для user_id={user_id}")
         return
 
-    salon = await orm_get_salon_by_id(session, user.salon_id)
+    user_salon = await orm_get_user_salon(session, user_id, user.salon_id)
+    salon = user_salon.salon if user_salon else None
     if not salon or not salon.group_chat_id:
         print(f"[notify] group_chat_id не найден для salon_id={user.salon_id}")
         return
 
     # ---------- чек для группы салона ----------
     group_summary = await get_order_summary(
-        session, user_id, user.salon_id, data, for_group=True
+        session, user_salon.id, data, for_group=True
     )
     await callback.bot.send_message(
         salon.group_chat_id,


### PR DESCRIPTION
## Summary
- accept `user_salon_id` in `get_order_summary` and derive salon via relationship
- introduce `UserSalon` model and helper query utilities
- update order and notification handlers to pass `user_salon_id`

## Testing
- `pytest` *(fails: No module named 'aiohttp'; No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_688e1759ac78832daf841e9566f7fb21