### PR TITLE
Ensure explicit salon selection in menu content

### DIFF
--- a/handlers/order_processing.py
+++ b/handlers/order_processing.py
@@ -11,7 +11,14 @@ from utils.notifications import notify_salon_about_order
 from utils.orders import get_order_summary
 from handlers.menu_processing import get_menu_content
 from utils.geo import haversine, calc_delivery_cost, get_address_from_coords
-from database.orm_query import orm_get_user_carts, orm_get_user, orm_get_salon_by_id, orm_clear_cart, orm_create_order
+from database.orm_query import (
+    orm_get_user_carts,
+    orm_get_user,
+    orm_get_salon_by_id,
+    orm_clear_cart,
+    orm_create_order,
+    orm_get_user_salons,
+)
 from database.models import UserSalon
 
 order_router = Router()
@@ -487,10 +494,19 @@ async def back_to_cart(callback: CallbackQuery, state: FSMContext, session: Asyn
     await state.clear()                     # ① очистили сразу
 
     user_id = callback.from_user.id
+    user_salons = await orm_get_user_salons(session, user_id)
+    if len(user_salons) != 1:
+        await callback.message.answer("Не удалось определить салон. Пожалуйста, выберите салон.")
+        await callback.answer()
+        return
+
+    user_salon_id = user_salons[0].id
     image, kbds = await get_menu_content(
         session=session,
-        level=3, menu_name="main",
-        page=1, user_id=user_id
+        level=3,
+        menu_name="main",
+        page=1,
+        user_salon_id=user_salon_id,
     )
 
     try:


### PR DESCRIPTION
## Summary
- extend `get_menu_content` to accept `salon_id` and fail when salon is ambiguous
- adjust order flow to fetch chosen `user_salon_id` before opening cart

## Testing
- `pytest -q` *(fails: TokenValidationError: Token is invalid!)*

------
https://chatgpt.com/codex/tasks/task_e_688e4b359018832db9860771df16c373