### PR TITLE
Require explicit user_salon_id for salon notifications

### DIFF
--- a/handlers/order_processing.py
+++ b/handlers/order_processing.py
@@ -461,7 +461,7 @@ async def confirm_order(callback: CallbackQuery,
             cart_items=cart_items,
         )
         # 4. Уведомляем салон ДО очистки FSM и корзины!
-        await notify_salon_about_order(callback, state, session)
+        await notify_salon_about_order(callback, state, session, user_salon_id)
         # 5. Очищаем корзину
         await orm_clear_cart(session, user_salon_id)
         # 6. Убираем inline-кнопки

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -3,7 +3,7 @@ from aiogram.types import (
 )
 from aiogram.fsm.context import FSMContext
 from sqlalchemy.ext.asyncio import AsyncSession
-from database.orm_query import orm_get_user, orm_get_salon_by_id
+from database.orm_query import orm_get_salon_by_id
 from database.models import UserSalon
 from utils.orders import get_order_summary
 
@@ -24,13 +24,15 @@ async def notify_salon_about_order(
     callback: CallbackQuery,
     state: FSMContext,
     session: AsyncSession,
+    user_salon_id: int,
 ) -> None:
     data    = await state.get_data()
     user_id = callback.from_user.id
     phone   = data.get("phone") or "Нет номера"
 
-    user_salon_id = data.get("user_salon_id")
-    user = await session.get(UserSalon, user_salon_id) if user_salon_id else await orm_get_user(session, user_id)
+    assert data.get("user_salon_id") is not None, "user_salon_id missing in FSM state"
+
+    user = await session.get(UserSalon, user_salon_id)
     if not user or not user.salon_id:
         print(f"[notify] salon_id не найден для user_id={user_id}")
         return


### PR DESCRIPTION
## Summary
- require user_salon_id parameter in salon notification helper
- ensure FSM state contains user_salon_id and drop orm_get_user fallback
- pass user_salon_id when confirming orders

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp'; No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_688e506709d0832d84995d1ae432ca66