### PR TITLE
Add role-based bot commands

### DIFF
--- a/common/bot_cmds_list.py
+++ b/common/bot_cmds_list.py
@@ -1,8 +1,22 @@
-from aiogram.types import BotCommand
+from aiogram import Bot
+from aiogram.types import BotCommand, BotCommandScopeChat
 
-# Определение команд для приватного чата
-private = [
-    BotCommand(command='menu', description='Посмотреть меню'),
-    BotCommand(command='about', description='О нас'),
-    BotCommand(command='payment', description='Варианты оплаты'),
-    BotCommand(command='shipping', description='Варианты доставки'),]
+
+# Команды для обычных пользователей
+user_commands = [
+    BotCommand(command="start", description="Запустить бота"),
+]
+
+
+# Команды для администраторов
+admin_commands = user_commands + [
+    BotCommand(command="admin", description="Админ-панель"),
+    BotCommand(command="orders", description="Текущие заказы"),
+]
+
+
+async def set_commands(bot: Bot, user_id: int, is_admin: bool) -> None:
+    """Устанавливает список команд для конкретного пользователя."""
+    commands = admin_commands if is_admin else user_commands
+    await bot.set_my_commands(commands, scope=BotCommandScopeChat(chat_id=user_id))
+

--- a/handlers/user_private.py
+++ b/handlers/user_private.py
@@ -14,12 +14,14 @@ from database.orm_query import (
     orm_get_salon_by_slug,
     orm_get_product,
     orm_get_products,
+    orm_get_user,
 )
 
 from filters.chat_types import ChatTypeFilter
 from handlers.invite_creation import InviteFilter
 from handlers.menu_processing import get_menu_content, products
 from kbds.inline import MenuCallBack, get_callback_btns, SalonCallBack, get_salon_btns
+from common.bot_cmds_list import set_commands
 
 
 
@@ -41,6 +43,10 @@ async def start_cmd(message: types.Message, state: FSMContext, session: AsyncSes
         user = User(user_id=user_id)
         session.add(user)
         await session.commit()
+
+    user_record = await orm_get_user(session, user_id)
+    is_admin = bool(user_record and (user_record.is_super_admin or user_record.is_salon_admin))
+    await set_commands(message.bot, user_id, is_admin)
 
     salons = await orm_get_salons(session)
     if not salons:

--- a/handlersadmin/menu.py
+++ b/handlersadmin/menu.py
@@ -7,6 +7,8 @@ from aiogram import Router, F
 from aiogram.client.bot import Bot
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command
+from filters.chat_types import ChatTypeFilter, IsAdmin
+from common.bot_cmds_list import set_commands
 from aiogram.fsm.context import FSMContext
 from aiogram.types import (
     CallbackQuery,
@@ -22,6 +24,8 @@ from database.orm_query import orm_get_user_salons
 # ──────────────────────────────────────────────────────────────────────────
 
 admin_menu_router = Router()
+admin_menu_router.message.filter(ChatTypeFilter(["private"]), IsAdmin())
+admin_menu_router.callback_query.filter(IsAdmin())
 
 
 # ─────────────────────────── клавиатура админ‑меню ───────────────────────
@@ -133,6 +137,7 @@ async def open_admin(message: Message,
             await state.update_data(salon_id=user_salons[0].salon_id)
 
     await show_admin_menu(state, message.chat.id, message.bot, session)
+    await set_commands(message.bot, message.from_user.id, True)
 
 
 @admin_menu_router.callback_query(F.data == "admin_menu")

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ load_dotenv(find_dotenv())
 
 from middlewares.db import DataBaseSession
 from database.engine import  drop_db, session_maker
+from common.bot_cmds_list import user_commands
 
 from handlers.user_private import user_private_router
 from handlers.admin_private import admin_router
@@ -54,7 +55,9 @@ dp.include_router(invite_link_router)
 dp.include_router(invite_creation_router)
 
 async def on_startup(bot):
-    pass
+    await bot.set_my_commands(
+        user_commands, scope=types.BotCommandScopeAllPrivateChats()
+    )
 
 async def on_shutdown(bot):
     print('бот лег')
@@ -66,8 +69,6 @@ async def main():
     dp.update.middleware(DataBaseSession(session_pool=session_maker))
 
     await bot.delete_webhook(drop_pending_updates=True)
-    # await bot.delete_my_commands(scope=types.BotCommandScopeAllPrivateChats())
-    # await bot.set_my_commands(commands=private, scope=types.BotCommandScopeAllPrivateChats())
     await dp.start_polling(bot, allowed_updates=dp.resolve_used_update_types())
 
 asyncio.run(main())


### PR DESCRIPTION
## Summary
- Introduce user and admin command sets with dynamic assignment
- Restrict admin/menu routes to admins and add `/orders` command
- Configure bot to set default commands on startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898741561bc832d8be9cc5a7d692555