### PR TITLE
Use code-based banner descriptions with admin override

### DIFF
--- a/common/texts_for_db.py
+++ b/common/texts_for_db.py
@@ -57,3 +57,9 @@ images_for_info_pages = {
     "catalog": "banners/catalog.jpg",
     "cart": "banners/cart.jpg",
 }
+
+# ``description_for_info_pages`` contains placeholder entries for banner
+# descriptions. ``None`` values mean that the application will use
+# ``get_default_banner_description`` until an administrator sets a custom
+# description in the database.
+description_for_info_pages = {key: None for key in images_for_info_pages}

--- a/tests/test_banner_description.py
+++ b/tests/test_banner_description.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+from aiogram.utils.i18n import I18n
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from handlers.menu_processing import resolve_banner_description
+from common.texts_for_db import get_default_banner_description
+import common.texts_for_db as texts_for_db
+
+# Initialize i18n context so gettext works without raising LookupError
+i18n = I18n(path=Path(__file__).resolve().parents[1] / "locales", default_locale="ru")
+i18n.ctx_locale.set("ru")
+texts_for_db._ = lambda s: s
+
+
+def test_default_used_when_banner_missing():
+    assert (
+        resolve_banner_description(None, "main")
+        == get_default_banner_description("main")
+    )
+
+
+def test_default_used_when_description_none():
+    banner = SimpleNamespace(description=None)
+    assert (
+        resolve_banner_description(banner, "main")
+        == get_default_banner_description("main")
+    )
+
+
+def test_custom_description_has_priority():
+    custom = "My banner"
+    banner = SimpleNamespace(description=custom)
+    assert resolve_banner_description(banner, "main") == custom


### PR DESCRIPTION
## Summary
- ensure banners use code-defined text until an admin edits the description
- avoid overwriting custom descriptions when initializing salon banners
- test banner description priority between defaults and custom values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a249c4758c832da17d94007ce3e6a0