### PR TITLE
Allow cart additions without init data

### DIFF
--- a/web_app/templates/products_list.html
+++ b/web_app/templates/products_list.html
@@ -28,7 +28,7 @@
 
           <button
               class="btn btn-sm btn-primary mt-auto"
-              hx-post="/{{ salon_slug }}/cart/add/{{ product.id }}?init_data={{ init_data|urlencode }}"
+              hx-post="/{{ salon_slug }}/cart/add/{{ product.id }}"
               hx-trigger="click"
               hx-swap="none">
             Добавить в корзину


### PR DESCRIPTION
## Summary
- Accept user_salon cookie in cart addition requests and set it when necessary
- Remove `init_data` parameter from cart add buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac909c467c832d9fce07034970835c