### PR TITLE
Add checkout flow with delivery options and auto-filled contact

### DIFF
--- a/alembic/versions/7cdb2b3c0a5d_add_checkout_fields.py
+++ b/alembic/versions/7cdb2b3c0a5d_add_checkout_fields.py
@@ -1,0 +1,41 @@
+"""add checkout fields
+
+Revision ID: 7cdb2b3c0a5d
+Revises: a552f6302e19
+Create Date: 2024-02-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "7cdb2b3c0a5d"
+down_revision: Union[str, Sequence[str], None] = "a552f6302e19"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("orders", sa.Column("name", sa.String(length=150), nullable=False))
+    op.add_column("orders", sa.Column("email", sa.String(length=150), nullable=True))
+    op.add_column("orders", sa.Column("delivery_type", sa.String(length=20), nullable=False))
+    op.add_column("orders", sa.Column("comment", sa.Text(), nullable=True))
+    op.alter_column("orders", "phone", existing_type=sa.String(length=20), nullable=False)
+    op.alter_column(
+        "orders", "payment_method", existing_type=sa.String(length=20), nullable=False
+    )
+    op.add_column("order_item", sa.Column("product_name", sa.String(length=150), nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("order_item", "product_name")
+    op.alter_column(
+        "orders", "payment_method", existing_type=sa.String(length=20), nullable=True
+    )
+    op.alter_column("orders", "phone", existing_type=sa.String(length=20), nullable=True)
+    op.drop_column("orders", "comment")
+    op.drop_column("orders", "delivery_type")
+    op.drop_column("orders", "email")
+    op.drop_column("orders", "name")

--- a/database/models.py
+++ b/database/models.py
@@ -145,9 +145,13 @@ class Order(Base):
     user_salon_id: Mapped[int] = mapped_column(
         ForeignKey('user_salon.id'), nullable=False
     )
+    name: Mapped[str] = mapped_column(String(150))
+    phone: Mapped[str] = mapped_column(String(20))
+    email: Mapped[str | None] = mapped_column(String(150), nullable=True)
     address: Mapped[str | None] = mapped_column(Text, nullable=True)
-    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    payment_method: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    delivery_type: Mapped[str] = mapped_column(String(20))
+    payment_method: Mapped[str] = mapped_column(String(20))
+    comment: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String(20), default="NEW")
     total: Mapped[float] = mapped_column(Numeric(10, 2))
 
@@ -160,6 +164,7 @@ class OrderItem(Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order_id: Mapped[int] = mapped_column(ForeignKey('orders.id', ondelete='CASCADE'))
     product_id: Mapped[int] = mapped_column(ForeignKey('product.id'))
+    product_name: Mapped[str] = mapped_column(String(150))
     quantity: Mapped[int]
     price: Mapped[float] = mapped_column(Numeric(10, 2))
 

--- a/database/orm_query.py
+++ b/database/orm_query.py
@@ -482,9 +482,13 @@ async def orm_clear_cart(session: AsyncSession, user_salon_id: int) -> None:
 async def orm_create_order(
     session: AsyncSession,
     user_salon_id: int,
+    name: str,
+    phone: str,
+    email: str | None,
     address: str | None,
-    phone: str | None,
-    payment_method: str | None,
+    delivery_type: str,
+    payment_method: str,
+    comment: str | None,
     cart_items: list,
     status: str = "NEW",
 ) -> "Order":
@@ -494,9 +498,13 @@ async def orm_create_order(
 
     order = Order(
         user_salon_id=user_salon_id,
-        address=address,
+        name=name,
         phone=phone,
+        email=email,
+        address=address,
+        delivery_type=delivery_type,
         payment_method=payment_method,
+        comment=comment,
         status=status,
         total=total,
     )
@@ -508,6 +516,7 @@ async def orm_create_order(
             OrderItem(
                 order_id=order.id,
                 product_id=item.product_id,
+                product_name=item.product.name,
                 quantity=item.quantity,
                 price=item.product.price,
             )

--- a/web_app/routes/orders.py
+++ b/web_app/routes/orders.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, EmailStr
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from database.models import Cart, UserSalon
+from database.orm_query import orm_create_order, orm_get_salon_by_slug
+from ..web_main import get_session, templates
+
+
+router = APIRouter()
+
+
+class CheckoutForm(BaseModel):
+    name: str
+    phone: str
+    email: EmailStr | None = None
+    address: str | None = None
+    delivery_type: str
+    payment_method: str
+    comment: str | None = None
+
+
+@router.get("/{salon_slug}/checkout", response_class=HTMLResponse)
+async def checkout_page(
+    request: Request,
+    salon_slug: str,
+    delivery_type: str = "delivery",
+    session: AsyncSession = Depends(get_session),
+):
+    user_salon_id = request.cookies.get("user_salon_id")
+    if not user_salon_id:
+        raise HTTPException(401, "User not identified")
+
+    salon = await orm_get_salon_by_slug(session, salon_slug)
+    if not salon:
+        raise HTTPException(status_code=404, detail="Salon not found")
+
+    link = await session.get(UserSalon, int(user_salon_id))
+    if not link or link.salon_id != salon.id:
+        raise HTTPException(403, "Access forbidden")
+
+    result = await session.execute(
+        select(Cart)
+            .where(Cart.user_salon_id == link.id)
+            .options(selectinload(Cart.product))
+            .order_by(Cart.id)
+    )
+    items = result.scalars().all()
+    total = sum(i.product.price * i.quantity for i in items)
+    cart_count = sum(i.quantity for i in items)
+
+    first = (link.first_name or "").strip()
+    last = (link.last_name or "").strip()
+    full = f"{first} {last}".strip()
+    welcome_name = full or first or last or None
+
+    template = "_checkout_cafe.html" if request.headers.get("HX-Request") else "checkout.html"
+    return templates.TemplateResponse(
+        template,
+        {
+            "request": request,
+            "salon_slug": salon.slug,
+            "salon_name": salon.name,
+            "welcome_name": welcome_name,
+            "cart_count": cart_count,
+            "total": total,
+            "delivery_type": delivery_type,
+        },
+    )
+
+
+@router.post("/{salon_slug}/checkout", response_class=HTMLResponse)
+async def checkout_submit(
+    request: Request,
+    salon_slug: str,
+    session: AsyncSession = Depends(get_session),
+):
+    user_salon_id = request.cookies.get("user_salon_id")
+    if not user_salon_id:
+        raise HTTPException(401, "User not identified")
+
+    salon = await orm_get_salon_by_slug(session, salon_slug)
+    if not salon:
+        raise HTTPException(status_code=404, detail="Salon not found")
+
+    link = await session.get(UserSalon, int(user_salon_id))
+    if not link or link.salon_id != salon.id:
+        raise HTTPException(403, "Access forbidden")
+
+    result = await session.execute(
+        select(Cart)
+            .where(Cart.user_salon_id == link.id)
+            .options(selectinload(Cart.product))
+            .order_by(Cart.id)
+    )
+    cart_items = result.scalars().all()
+    if not cart_items:
+        raise HTTPException(400, "Cart is empty")
+
+    form = await request.form()
+    data = CheckoutForm(**form)
+
+    await orm_create_order(
+        session,
+        user_salon_id=link.id,
+        name=data.name,
+        phone=data.phone,
+        email=data.email,
+        address=data.address,
+        delivery_type=data.delivery_type,
+        payment_method=data.payment_method,
+        comment=data.comment,
+        cart_items=cart_items,
+    )
+
+    await session.execute(delete(Cart).where(Cart.user_salon_id == link.id))
+    await session.commit()
+
+    token = os.getenv("TOKEN")
+    if token:
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"https://api.telegram.org/bot{token}/sendMessage",
+                    data={"chat_id": link.user_id, "text": "Спасибо за заказ"},
+                )
+        except Exception:
+            pass
+
+    # Close the mini app
+    return HTMLResponse("<script>Telegram.WebApp.ready();Telegram.WebApp.close();</script>")
+

--- a/web_app/templates/_cart_body.html
+++ b/web_app/templates/_cart_body.html
@@ -59,7 +59,7 @@
     </ul>
 
     <p class="fw-bold text-end" aria-live="polite">Итого: {{ "%.2f"|format(total) }} ₽</p>
-    <button type="button" class="btn btn-success w-100">Оформить заказ</button>
+    <a href="/{{ salon_slug }}/checkout" class="btn btn-success w-100">Оформить заказ</a>
   {% else %}
     <p>Корзина пуста</p>
   {% endif %}

--- a/web_app/templates/_checkout_cafe.html
+++ b/web_app/templates/_checkout_cafe.html
@@ -1,0 +1,72 @@
+<div>
+  <h3 class="mb-3">Оформление заказа</h3>
+  <form hx-post="/{{ salon_slug }}/checkout" hx-target="#checkout-form" hx-swap="outerHTML">
+    <div class="mb-3">
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="delivery_type" id="delivery" value="delivery"
+               {% if delivery_type != 'pickup' %}checked{% endif %}
+               hx-get="/{{ salon_slug }}/checkout?delivery_type=delivery" hx-target="#checkout-form" hx-swap="outerHTML">
+        <label class="form-check-label" for="delivery">Доставка</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="delivery_type" id="pickup" value="pickup"
+               {% if delivery_type == 'pickup' %}checked{% endif %}
+               hx-get="/{{ salon_slug }}/checkout?delivery_type=pickup" hx-target="#checkout-form" hx-swap="outerHTML">
+        <label class="form-check-label" for="pickup">Самовывоз</label>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Имя</label>
+      <input type="text" class="form-control" name="name" required>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Телефон</label>
+      <input type="text" class="form-control" id="phone-display" readonly>
+      <input type="hidden" name="phone" id="tg-phone">
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Email</label>
+      <input type="email" class="form-control" name="email">
+    </div>
+
+    {% if delivery_type == 'delivery' %}
+    <div class="mb-3">
+      <label class="form-label">Адрес</label>
+      <input type="text" class="form-control" name="address" required>
+    </div>
+    {% endif %}
+
+    <div class="mb-3">
+      <label class="form-label">Комментарий</label>
+      <textarea class="form-control" name="comment"></textarea>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Способ оплаты</label>
+      <select class="form-select" name="payment_method">
+        <option value="cash">Наличные</option>
+        <option value="card">Картой</option>
+      </select>
+    </div>
+
+    <p class="fw-bold text-end">Итого: {{ "%.2f"|format(total) }} ₽</p>
+    <button type="submit" class="btn btn-success w-100">Оформить</button>
+  </form>
+</div>
+
+<script>
+  (function(){
+    const tg = window.Telegram?.WebApp;
+    if(!tg) return;
+    tg.ready();
+    tg.requestContact(function(res){
+      if(res && res.phone_number){
+        document.getElementById('tg-phone').value = res.phone_number;
+        document.getElementById('phone-display').value = res.phone_number;
+      }
+    });
+  })();
+</script>

--- a/web_app/templates/checkout.html
+++ b/web_app/templates/checkout.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title %}Оформление заказа{% endblock %}
+
+{% block content %}
+  <div id="checkout-form">
+    {% include "_checkout_cafe.html" %}
+  </div>
+{% endblock %}

--- a/web_app/web_main.py
+++ b/web_app/web_main.py
@@ -303,6 +303,8 @@ async def load_category(
 
 from .routes.products import router as products_router
 from .routes.cart import router as cart_router
+from .routes.orders import router as orders_router
 
 app.include_router(products_router)
 app.include_router(cart_router)
+app.include_router(orders_router)


### PR DESCRIPTION
## Summary
- extend Order models to support delivery and pickup specifics
- add checkout endpoint with Pydantic validation and Telegram contact autofill
- provide HTMX-based templates for dynamic checkout form
- add Alembic migration for new order and order item fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add0ed2450832d8f5b14cd2bece095